### PR TITLE
Fix checking for VirtualBox v7.0

### DIFF
--- a/src/virtualbox_client/mod.rs
+++ b/src/virtualbox_client/mod.rs
@@ -144,7 +144,7 @@ impl VirtualBoxClient {
         }
 
         if raw_ver == "v7_0".to_string()
-            && (current_major != 7 || current_minor != 1 || BUILD_VER != 70)
+            && (current_major != 7 || current_minor != 0 || BUILD_VER != 70)
         {
             return error;
         }


### PR DESCRIPTION
It's not currently possible to use VBox 7.0, as the version check expects v7.1 and `init_uncheck` does not work (see #2).